### PR TITLE
Add timestamps to progress and error messages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.DS_Store
 *.pyc

--- a/README
+++ b/README
@@ -40,7 +40,7 @@ Caveat emptor.
 
 
 USAGE:
-usage: apod.py [-h] [-f] [-o] [-p PATH] [-s]
+usage: apod.py [-h] [-f] [-o] [-p PATH] [-s] [-t]
 
 wee little python script to grab NASA's APOD
 
@@ -51,6 +51,8 @@ optional arguments:
   -p PATH, --path PATH  path to store downloaded images in
   -s, --set             flag to cause the script to set the desktop background
                         to the downloaded image.
+  -t, --timestamp       flag to cause timestamps to be prepended to progress
+                        and error messages.
 
 
 I designed this to be a cronjob. My crontab entry looks like this:

--- a/README
+++ b/README
@@ -58,6 +58,9 @@ optional arguments:
 I designed this to be a cronjob. My crontab entry looks like this:
 15  22  *   *   *  python ${APOD_py}/apod.py -s 
 
+To log timestamped progress and error messages to a logfile, use this:
+15 22 * * * python apod.py -t >> /var/log/apod.log 2>&1 
+
 SYSTEMS WHERE BACKGROUND SETTING IS IMPLEMENTED:
     - OS X
     - GNOME

--- a/apod.py
+++ b/apod.py
@@ -85,6 +85,7 @@ temp        = tempfile.mkstemp()                        # temp file
 #        image filename.
 # image_size: number of bytes written
 today       = '_' + str(datetime.date.today()).replace('-', '')
+log_time    = datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%d %H:%M:%S")
 image_size  = 0
 
 
@@ -150,7 +151,7 @@ store_file  = store_dir + image_name
 # we won't download the image. If the force option is specified, the 
 # program will try to set the background.
 if os.access(store_file, os.F_OK) and not args.overwrite:
-    print 'file already exists!'
+    print '[' + log_time + '] file already exists!'
 
     if not args.force:
         sys.exit(4)
@@ -174,8 +175,8 @@ elif not os.access(store_file, os.F_OK) or args.overwrite:
     with open(store_file, 'wb+') as image_f:
         image_f.write(os.read(temp[0], image_size))
     
-    print 'file saved to ' + store_file
-    print 'download complete!'
+    print '[' + log_time + '] file saved to ' + store_file
+    print '[' + log_time + '] download complete!'
 
     # clean up the temp file
     u_path  = temp[1]
@@ -191,4 +192,4 @@ if args.set:
         print 'success!'
 
 # wew survived the gauntlet!
-print 'finished!'
+print '[' + log_time + '] finished!'

--- a/apod.py
+++ b/apod.py
@@ -43,7 +43,9 @@ def url_open(url_str):
         page 	= url.read()
 
     return page
-
+    
+def log_message(log_string):
+	return log_time + " " + log_string
 
 
 ############
@@ -120,8 +122,8 @@ if args.path:
 # ensure we have access to the directory we are trying to store images in
 # if not, mkdir()
 if not os.access(store_dir, os.W_OK):
-    print log_time + ' no write permissions on ' + store_dir + '!'
-    print log_time + ' creating ' + store_dir
+    print log_message('no write permissions on ' + store_dir + '!')
+    print log_message('creating ' + store_dir)
     try:
         os.makedirs(store_dir)
     except OSError:
@@ -153,16 +155,16 @@ store_file  = store_dir + image_name
 # we won't download the image. If the force option is specified, the 
 # program will try to set the background.
 if os.access(store_file, os.F_OK) and not args.overwrite:
-    print log_time + ' file already exists!'
+    print log_message('file already exists!')
 
     if not args.force:
         sys.exit(4)
 
 elif not os.access(store_file, os.F_OK) or args.overwrite:
-    if os.access(store_file, os.F_OK): print log_time + ' file exists...'
-    if args.overwrite: print log_time + ' will overwrite!'
+    if os.access(store_file, os.F_OK): print log_message('file exists...')
+    if args.overwrite: print log_message('will overwrite!')
     # save the image to a temporary file
-    print log_time + ' fetching ' + image_url
+    print log_message('fetching ' + image_url)
     image_size = os.write(temp[0], url_open(image_url))
 
     # need to seek to beginning of file to read out the image to the 
@@ -171,14 +173,14 @@ elif not os.access(store_file, os.F_OK) or args.overwrite:
 
 
     # diagnostic information
-    print log_time + ' will store as ' + store_file
+    print log_message('will store as ' + store_file)
     
     # save the file
     with open(store_file, 'wb+') as image_f:
         image_f.write(os.read(temp[0], image_size))
     
-    print log_time + ' file saved to ' + store_file
-    print log_time + ' download complete!'
+    print log_message('file saved to ' + store_file)
+    print log_message('download complete!')
 
     # clean up the temp file
     u_path  = temp[1]
@@ -187,11 +189,11 @@ elif not os.access(store_file, os.F_OK) or args.overwrite:
 
 # possibly set the background 
 if args.set:
-    print log_time + ' setting desktop background...'
+    print log_message('setting desktop background...')
     if not set_bg(store_file):
         sys.stderr.write('failed to set desktop background!\n')
     else:
-        print log_time + ' success!'
+        print log_message('success!')
 
 # wew survived the gauntlet!
-print log_time +  ' finished!'
+print log_message('finished!')

--- a/apod.py
+++ b/apod.py
@@ -46,12 +46,16 @@ def url_open(url_str):
 
 def log_message(log_string):
 	"""
-	Prepend a timestamp onto the progress and error messages if the command line
-	argument is set. Makes for a pretty log file.
+	Prepend a timestamp onto the progress and error messages if the
+	command line argument is set. Makes for a pretty log file.
 	"""
-	log_time    = datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%d %H:%M:%S")
-	log_time    = '[' + log_time + ']'
-	return log_time + " " + log_string
+	if args.timestamp:
+		log_time    = datetime.datetime.strftime(datetime.datetime.now(), \
+		              "%Y-%m-%d %H:%M:%S")
+		log_time    = '[' + log_time + ']'
+		return log_time + " " + log_string
+	else:
+		return log_string
 
 
 ############
@@ -112,6 +116,9 @@ parser.add_argument('-p', '--path', help = 'path to store downloaded '   +
 parser.add_argument('-s', '--set', action = 'store_true', help = 'flag ' +
                     'to cause the script to set the desktop background ' +
                     'to the downloaded image.')
+parser.add_argument('-t', '--timestamp', action = 'store_true',
+                    help = 'flag to cause timestamps to be prepended to' +
+                    ' progress and error messages.')
 args = parser.parse_args()
 
 

--- a/apod.py
+++ b/apod.py
@@ -36,7 +36,7 @@ def url_open(url_str):
     # something went wrong with the webserver
     except urllib2.HTTPError, e:
         err = sys.stderr.write
-        err('APOD download failed with HTTP error ', e.code, '\n')
+        err(log_message('APOD download failed with HTTP error '), e.code, '\n')
         sys.exit(2)
 
     else:
@@ -137,7 +137,7 @@ if not os.access(store_dir, os.W_OK):
     try:
         os.makedirs(store_dir)
     except OSError:
-        sys.stderr.write('could not create dir ' + store_dir + '!\n')
+        sys.stderr.write(log_message('could not create dir ') + store_dir + '!\n')
         sys.exit(2)
 
 # fetch page
@@ -154,7 +154,7 @@ for line in page:
 
 # check to make sure the image URL was actually pulled from the page
 if not image_url:
-    sys.stderr.write('error retrieving APOD filename!\n')
+    sys.stderr.write(log_message('error retrieving APOD filename!\n'))
     sys.exit(3)
 
 # filename to save image as
@@ -201,7 +201,7 @@ elif not os.access(store_file, os.F_OK) or args.overwrite:
 if args.set:
     print log_message('setting desktop background...')
     if not set_bg(store_file):
-        sys.stderr.write('failed to set desktop background!\n')
+        sys.stderr.write(log_message('failed to set desktop background!\n'))
     else:
         print log_message('success!')
 

--- a/apod.py
+++ b/apod.py
@@ -83,6 +83,7 @@ temp        = tempfile.mkstemp()                        # temp file
 ######################
 # today: the date in a string format appropriate for appending to the 
 #        image filename.
+# log_time: date and time formatted to be prepended to the status messages
 # image_size: number of bytes written
 today       = '_' + str(datetime.date.today()).replace('-', '')
 log_time    = datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%d %H:%M:%S")

--- a/apod.py
+++ b/apod.py
@@ -45,6 +45,8 @@ def url_open(url_str):
     return page
     
 def log_message(log_string):
+	log_time    = datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%d %H:%M:%S")
+	log_time    = '[' + log_time + ']'
 	return log_time + " " + log_string
 
 
@@ -88,8 +90,6 @@ temp        = tempfile.mkstemp()                        # temp file
 # log_time: date and time formatted to be prepended to the status messages
 # image_size: number of bytes written
 today       = '_' + str(datetime.date.today()).replace('-', '')
-log_time    = datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%d %H:%M:%S")
-log_time    = '[' + log_time + ']'
 image_size  = 0
 
 

--- a/apod.py
+++ b/apod.py
@@ -43,8 +43,12 @@ def url_open(url_str):
         page 	= url.read()
 
     return page
-    
+
 def log_message(log_string):
+	"""
+	Prepend a timestamp onto the progress and error messages if the command line
+	argument is set. Makes for a pretty log file.
+	"""
 	log_time    = datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%d %H:%M:%S")
 	log_time    = '[' + log_time + ']'
 	return log_time + " " + log_string
@@ -87,7 +91,6 @@ temp        = tempfile.mkstemp()                        # temp file
 ######################
 # today: the date in a string format appropriate for appending to the 
 #        image filename.
-# log_time: date and time formatted to be prepended to the status messages
 # image_size: number of bytes written
 today       = '_' + str(datetime.date.today()).replace('-', '')
 image_size  = 0

--- a/apod.py
+++ b/apod.py
@@ -86,6 +86,7 @@ temp        = tempfile.mkstemp()                        # temp file
 # image_size: number of bytes written
 today       = '_' + str(datetime.date.today()).replace('-', '')
 log_time    = datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%d %H:%M:%S")
+log_time    = '[' + log_time + ']'
 image_size  = 0
 
 
@@ -118,8 +119,8 @@ if args.path:
 # ensure we have access to the directory we are trying to store images in
 # if not, mkdir()
 if not os.access(store_dir, os.W_OK):
-    print 'no write permissions on ' + store_dir + '!'
-    print 'creating ' + store_dir
+    print log_time + ' no write permissions on ' + store_dir + '!'
+    print log_time + ' creating ' + store_dir
     try:
         os.makedirs(store_dir)
     except OSError:
@@ -151,16 +152,16 @@ store_file  = store_dir + image_name
 # we won't download the image. If the force option is specified, the 
 # program will try to set the background.
 if os.access(store_file, os.F_OK) and not args.overwrite:
-    print '[' + log_time + '] file already exists!'
+    print log_time + ' file already exists!'
 
     if not args.force:
         sys.exit(4)
 
 elif not os.access(store_file, os.F_OK) or args.overwrite:
-    if os.access(store_file, os.F_OK): print 'file exists...'
-    if args.overwrite: print 'will overwrite!'
+    if os.access(store_file, os.F_OK): print log_time + ' file exists...'
+    if args.overwrite: print log_time + ' will overwrite!'
     # save the image to a temporary file
-    print 'fetching ' + image_url
+    print log_time + ' fetching ' + image_url
     image_size = os.write(temp[0], url_open(image_url))
 
     # need to seek to beginning of file to read out the image to the 
@@ -169,14 +170,14 @@ elif not os.access(store_file, os.F_OK) or args.overwrite:
 
 
     # diagnostic information
-    print 'will store as ' + store_file
+    print log_time + ' will store as ' + store_file
     
     # save the file
     with open(store_file, 'wb+') as image_f:
         image_f.write(os.read(temp[0], image_size))
     
-    print '[' + log_time + '] file saved to ' + store_file
-    print '[' + log_time + '] download complete!'
+    print log_time + ' file saved to ' + store_file
+    print log_time + ' download complete!'
 
     # clean up the temp file
     u_path  = temp[1]
@@ -185,11 +186,11 @@ elif not os.access(store_file, os.F_OK) or args.overwrite:
 
 # possibly set the background 
 if args.set:
-    print 'setting desktop background...'
+    print log_time + ' setting desktop background...'
     if not set_bg(store_file):
         sys.stderr.write('failed to set desktop background!\n')
     else:
-        print 'success!'
+        print log_time + ' success!'
 
 # wew survived the gauntlet!
-print '[' + log_time + '] finished!'
+print log_time +  ' finished!'


### PR DESCRIPTION
I have been using your script to save APOD files for use as my desktop. I thought it would be interesting save the progress and error messages to a log file in order to provide a quick check that images were being downloaded daily with no errors. I thought that adding timestamps to the output and error messages would help make the log file easier to read and diagnose if problems were to occur. I added the functionality as a command line option and simply wrapped the output text in a function call that prepended the timestamp if the command line option had been set.